### PR TITLE
feat: Enhance knowledge gap generation for tangential topic exploration

### DIFF
--- a/src/deepresearcher2/graph.py
+++ b/src/deepresearcher2/graph.py
@@ -142,15 +142,18 @@ class ReflectOnSearch(BaseNode[DeepState]):
 
             # Reflect on the summaries so far
             async with reflection_agent.run_mcp_servers():
-                reflection = await reflection_agent.run(
+                reflection_run_output = await reflection_agent.run( # Name changed for clarity
                     user_prompt=f"Please reflect on the provided web search summaries for the topic <TOPIC>{ctx.state.topic}</TOPIC>."
                 )
-                logger.debug(f"Reflection knowledge gaps:\n{reflection.output.knowledge_gaps}")
-                logger.debug(f"Reflection covered topics:\n{reflection.output.covered_topics}")
+                # reflection_run_output.output should now contain knowledge_gaps, covered_topics, AND exploratory_paths
+                logger.debug(f"Reflection knowledge gaps:\n{reflection_run_output.output.knowledge_gaps}")
+                logger.debug(f"Reflection covered topics:\n{reflection_run_output.output.covered_topics}")
+                logger.debug(f"Reflection exploratory paths:\n{reflection_run_output.output.exploratory_paths}")
 
-                ctx.state.reflection = Reflection(
-                    knowledge_gaps=reflection.output.knowledge_gaps,
-                    covered_topics=reflection.output.covered_topics,
+                ctx.state.reflection = Reflection( # This is our model from models.py
+                    knowledge_gaps=reflection_run_output.output.knowledge_gaps,
+                    covered_topics=reflection_run_output.output.covered_topics,
+                    exploratory_paths=reflection_run_output.output.exploratory_paths,
                 )
 
             return WebSearch()

--- a/src/deepresearcher2/models.py
+++ b/src/deepresearcher2/models.py
@@ -53,6 +53,7 @@ class WebSearchSummary(BaseModel):
 class Reflection(BaseModel):
     knowledge_gaps: list[str] = Field(..., description="aspects of the topic which require further exploration")
     covered_topics: list[str] = Field(..., description="aspects of the topic which have already been covered sufficiently")
+    exploratory_paths: list[str] | None = Field(default=None, description="List of tangentially related topics or questions for novel insights.")
 
 
 class FinalSummary(BaseModel):

--- a/src/deepresearcher2/prompts.py
+++ b/src/deepresearcher2/prompts.py
@@ -38,15 +38,17 @@ based on specific knowledge gaps.
 You will receive reflections in XML with `<reflections>` tags containing:
 - `<knowledge_gaps>`: information that has not been covered in the previous search results
 - `<covered_topics>`: information that has been covered and should not be repeated
+- `<exploratory_paths>`: a list of tangentially related topics or questions for novel insights. (Optional: this may not always be present)
 </INPUT_FORMAT>
 
 <REQUIREMENTS>
 1. The knowledge gaps form the basis of the search query.
-2. Identify the most relevant point in the knowledge gaps and use it to create a focused search query.
-3. Pick only one item from the list of knowledge gaps. Do not include all knowledge gaps in the construction of the query.
-4. Check that the query is not covering any aspects listed in the list of covered topics.
-5. Check that the query is at least vaguely related to the topic.
-6. Do not include the topic in the aspect of the query, since this is too broad.
+2. If `exploratory_paths` are provided and are not empty in the reflection, consider them. One of your generated queries (if generating multiple, or the primary one if single) OR your primary focus for the query should be to bridge the main topic with one of the `exploratory_paths`. Frame the query to investigate this connection.
+3. Identify the most relevant point in the `knowledge_gaps` (especially one derived from an `exploratory_path`, if applicable) and use it to create a focused search query.
+4. Pick only one item from the list of knowledge gaps or exploratory paths to be the primary focus for the query. Do not include all knowledge gaps, or multiple exploratory paths in the construction of the query.
+5. Check that the query is not covering any aspects listed in the list of covered topics.
+6. Check that the query is at least vaguely related to the topic.
+7. Do not include the topic in the aspect of the query, since this is too broad.
 </REQUIREMENTS>
 
 <OUTPUT_FORMAT>
@@ -115,14 +117,17 @@ You will receive web search summaries in XML with `<WebSearchSummary>` tags cont
 6. Return only the JSON object - no explanations or formatting
 7. Consider technical details, implementation specifics, and emerging trends
 8. Consider second and third-order effects or implications of the topic when exploring knowledge gaps
-9. Be thorough yet concise
-10. Ensure that the list of knowledgae gaps and the list of covered topics are distinct and do not overlap.
+9. Identify 1-2 'exploratory paths'. These are topics or questions that are tangentially related to the main subject but could offer novel insights or connections. Think about distant analogies, related fields, or 'what if' scenarios.
+10. Be thorough yet concise
+11. At least one of the identified `knowledge_gaps` should be directly inspired by or aim to bridge towards an `exploratory_path`.
+12. Ensure that the list of knowledgae gaps and the list of covered topics are distinct and do not overlap.
 </REQUIREMENTS>
 
 <OUTPUT_FORMAT>
 Respond with a JSON object containing:
 - "knowledge_gaps": List of specific aspects requiring further research
 - "covered_topics": List of aspects already thoroughly covered
+- "exploratory_paths": List of 1-2 tangentially related topics or questions for novel insights
 </OUTPUT_FORMAT>
 
 <EXAMPLE_OUTPUT>
@@ -139,6 +144,10 @@ Respond with a JSON object containing:
         "basic definition",
         "etymology",
         "general description"
+    ],
+    "exploratory_paths": [
+        "historical precedents of similar phenomena",
+        "cross-species olfactory responses to rain"
     ]
 }
 ```


### PR DESCRIPTION
This change aims to improve the diversity of generated knowledge gaps by prompting me to explore topics tangentially related to your original research subject.

Modifications include:

1.  **Prompts (`prompts.py`):**
    *   `reflection_instructions`: I've updated this to explicitly request that I generate "exploratory paths" (tangential ideas) and to ensure at least one knowledge gap is inspired by these paths. The output format now includes `exploratory_paths`.
    *   `query_instructions_with_reflection`: I've updated this to accept `exploratory_paths` as input and to prioritize generating search queries that bridge the main topic with one of these exploratory paths.

2.  **Models (`models.py`):**
    *   The `Reflection` Pydantic model now includes an optional field `exploratory_paths: list[str] | None` to store these identified tangential paths.

3.  **Graph Logic (`graph.py`):**
    *   `ReflectOnSearch` node: I've modified this to extract the `exploratory_paths` from my reflection output and store them in the `DeepState`. Logging for these paths has also been added.
    *   `WebSearch` node: No changes were needed as the existing XML serialization of the `Reflection` object automatically includes the new `exploratory_paths` field for my query generation.

These changes are intended to make the research process more creative and capable of uncovering less obvious connections and insights by guiding me to look beyond the immediate scope of the topic.